### PR TITLE
Render links as text only, ignoring URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.0.7] - 2024-09-12
+
+- Changed
+  - Rendered hyperlinks as texts only
+- Full diff
+  - https://github.com/jsh9/markdown-toc-creator/compare/0.0.6...0.0.7
+
 ## [0.0.6] - 2024-01-08
 
 - Fixed

--- a/markdown_toc_creator/toc_entry.py
+++ b/markdown_toc_creator/toc_entry.py
@@ -1,8 +1,8 @@
 import re
+import warnings
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import List, Literal, Set
-import warnings
 
 import bs4
 
@@ -29,7 +29,7 @@ class TocEntry:
         # remove HTML tags
         with warnings.catch_warnings():
             warnings.filterwarnings(
-                action="ignore", category=bs4.MarkupResemblesLocatorWarning
+                action='ignore', category=bs4.MarkupResemblesLocatorWarning
             )
             soup = bs4.BeautifulSoup(text, 'html.parser')
             text = soup.get_text()

--- a/markdown_toc_creator/toc_entry.py
+++ b/markdown_toc_creator/toc_entry.py
@@ -2,8 +2,9 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import List, Literal, Set
+import warnings
 
-from bs4 import BeautifulSoup
+import bs4
 
 
 class TocEntry:
@@ -26,8 +27,12 @@ class TocEntry:
         text = self.removePoundChar(self.displayText)
 
         # remove HTML tags
-        soup = BeautifulSoup(text, 'html.parser')
-        text = soup.get_text()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                action="ignore", category=bs4.MarkupResemblesLocatorWarning
+            )
+            soup = bs4.BeautifulSoup(text, 'html.parser')
+            text = soup.get_text()
 
         return self.convertToAnkerLink(text=text, style=self.style)
 
@@ -47,6 +52,7 @@ class TocEntry:
             text = re.sub(r':[\w\d_]+:', '', text)
 
         text = text.lower()
+        text = re.sub(r'\[(.*?)]\(.*?\)', '\\1', text)
 
         listOfCharGroups: List[_CharGroup] = _buildListOfCharGroups(text)
         anchorLink: str = _constructAnchorLink(listOfCharGroups)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+
+[tool.cercis]
+wrap-line-with-long-string = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = markdown_toc_creator
-version = 0.0.6
+version = 0.0.7
 description = Create table of contents for markdown files
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_toc_entry.py
+++ b/tests/test_toc_entry.py
@@ -2,7 +2,11 @@ from typing import List
 
 import pytest
 
-from markdown_toc_creator.toc_entry import _buildListOfCharGroups, _CharGroup, TocEntry
+from markdown_toc_creator.toc_entry import (
+    TocEntry,
+    _buildListOfCharGroups,
+    _CharGroup,
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_toc_entry.py
+++ b/tests/test_toc_entry.py
@@ -2,7 +2,7 @@ from typing import List
 
 import pytest
 
-from markdown_toc_creator.toc_entry import _buildListOfCharGroups, _CharGroup
+from markdown_toc_creator.toc_entry import _buildListOfCharGroups, _CharGroup, TocEntry
 
 
 @pytest.mark.parametrize(
@@ -92,3 +92,13 @@ from markdown_toc_creator.toc_entry import _buildListOfCharGroups, _CharGroup
 def testBuildListOfCharGroups(string: str, expected: List[_CharGroup]) -> None:
     result = _buildListOfCharGroups(string)
     assert result == expected
+
+
+def test_link_removal():
+    entry = TocEntry('hello world [somelink](https://foo.bar)', '', 'github')
+    assert entry.anchorLinkText == '#hello-world-somelink'
+
+
+def test_emoji_at_beginning():
+    entry = TocEntry('🐧 hello world', '', 'github')
+    assert entry.anchorLinkText == '#-hello-world'


### PR DESCRIPTION
Closes #4

(Needed for https://github.com/scientific-python/spin/pull/234/files)