### PR TITLE
Avoid links in ToC displaytext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.0.8] - 2024-09-16
+
+- Changed
+  - Strip links inside headings before including them in ToC
+- Full diff
+  - https://github.com/jsh9/markdown-toc-creator/compare/0.0.7...0.0.8
+
 ## [0.0.7] - 2024-09-12
 
 - Changed

--- a/markdown_toc_creator/toc_entry.py
+++ b/markdown_toc_creator/toc_entry.py
@@ -21,6 +21,7 @@ class TocEntry:
 
     def render(self) -> str:
         text = self.removePoundChar(self.displayText)
+        text = self.mdLinkToText(text)
         return self.indent + f'- [{text}]({self.anchorLinkText})'
 
     def _calcAnchorLinkText(self) -> str:
@@ -42,6 +43,12 @@ class TocEntry:
         return re.sub(r'^#+\s', '', string)
 
     @classmethod
+    def mdLinkToText(cls, string: str) -> str:
+        # Replace markdown links with their display text
+        # E.g., [my site](mysite.com) -> my site
+        return re.sub(r'\[(.*?)]\(.*?\)', '\\1', string)
+
+    @classmethod
     def convertToAnkerLink(
             cls,
             text: str,
@@ -52,7 +59,7 @@ class TocEntry:
             text = re.sub(r':[\w\d_]+:', '', text)
 
         text = text.lower()
-        text = re.sub(r'\[(.*?)]\(.*?\)', '\\1', text)
+        text = cls.mdLinkToText(text)
 
         listOfCharGroups: List[_CharGroup] = _buildListOfCharGroups(text)
         anchorLink: str = _constructAnchorLink(listOfCharGroups)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = markdown_toc_creator
-version = 0.0.7
+version = 0.0.8
 description = Create table of contents for markdown files
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/data/test1.md
+++ b/tests/data/test1.md
@@ -68,4 +68,8 @@ b = 1
 
 ## Here is `hello_?and!_world`
 
+## 🌻 This is a sunflower
+
+## This is a [link to pypi](https://pypi.org/project/markdown-toc-creator/)
+
 <!-- prettier-ignore-end -->

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -37,6 +37,8 @@ def testCreateToc(style: str) -> None:
             '    - [Hello _**world**_](#hello-world-4)',
             '    - [Hello *__world__*](#hello-world-5)',
             '  - [Here is `hello_?and!_world`](#here-is-hello_and_world)',
+            '  - [🌻 This is a sunflower](#-this-is-a-sunflower)',
+            '  - [This is a link to pypi](#this-is-a-link-to-pypi)',
         ],
         'gitlab': [
             '- [This header has spaces in it](#this-header-has-spaces-in-it)',
@@ -54,6 +56,8 @@ def testCreateToc(style: str) -> None:
             '    - [Hello _**world**_](#hello-world-4)',
             '    - [Hello *__world__*](#hello-world-5)',
             '  - [Here is `hello_?and!_world`](#here-is-hello_and_world)',
+            '  - [🌻 This is a sunflower](#-this-is-a-sunflower)',
+            '  - [This is a link to pypi](#this-is-a-link-to-pypi)',
         ],
     }
     assert tocLines == expected[style]

--- a/tests/test_toc_entry.py
+++ b/tests/test_toc_entry.py
@@ -100,9 +100,10 @@ def testBuildListOfCharGroups(string: str, expected: List[_CharGroup]) -> None:
 
 def test_link_removal():
     entry = TocEntry('hello world [somelink](https://foo.bar)', '', 'github')
-    assert entry.anchorLinkText == '#hello-world-somelink'
+    assert entry.render() == '- [hello world somelink](#hello-world-somelink)'
 
 
 def test_emoji_at_beginning():
     entry = TocEntry('🐧 hello world', '', 'github')
     assert entry.anchorLinkText == '#-hello-world'
+    assert entry.render() == '- [🐧 hello world](#-hello-world)'


### PR DESCRIPTION
When a heading contains links, the link *to* that heading cannot also contain links. E.g., a heading may contain

`This is [my site](https://mysite.org)`

in which case the ToC entry should render:

- [This is my site](#this-is-my-site)

Closes #6